### PR TITLE
fix: set repository branch to master for Colab/Binder launch buttons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ exclude_patterns:
 repository:
   url: https://github.com/jirvingphd/Online-DS-FT-022221-Cohort-Notes-FLEX
   path_to_book: ""
-  branch: main
+  branch: master
 
 # Add GitHub buttons to your book
 html:


### PR DESCRIPTION
This pull request makes a minor configuration update by changing the default branch for the repository in the `_config.yml` file from `main` to `master`.